### PR TITLE
Integration von default eventbus via 'mitt' package

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,11 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
+    "all": "^0.0.0",
     "bootstrap": "^5.2.3",
     "core-js": "^3.8.3",
     "firebase": "^9.19.1",
+    "mitt": "^3.0.0",
     "vue": "^3.2.13",
     "vue-router": "^4.0.3",
     "vuex": "^4.0.0"

--- a/src/main.js
+++ b/src/main.js
@@ -4,5 +4,10 @@ import router from './router'
 import store from './store'
 import 'bootstrap/dist/css/bootstrap.css'
 import 'bootstrap/dist/js/bootstrap.bundle.min.js'
+import mitt from 'mitt'
 
-createApp(App).use(store).use(router).mount('#app')
+const emitter = mitt()
+
+const app = createApp(App).use(store).use(router)
+app.config.globalProperties.emitter = emitter
+app.mount('#app')


### PR DESCRIPTION
Mit Vue3 gibt es nicht mehr die Möglichkeit, übers Root Element einen EventBus laufen zu lassen, daher die Integration von 'mitt' als default